### PR TITLE
[depends] libgcrypt: fix Neon usage on armv7

### DIFF
--- a/tools/depends/target/libgcrypt/02-fix-armv7-neon.patch
+++ b/tools/depends/target/libgcrypt/02-fix-armv7-neon.patch
@@ -1,0 +1,32 @@
+--- configure.ac.orig	2017-10-11 11:20:51.572217383 +0200
++++ configure.ac	2017-10-11 11:23:40.384215754 +0200
+@@ -2083,10 +2083,6 @@
+       arm*-*-*)
+          # Build with the assembly implementation
+          GCRYPT_CIPHERS="$GCRYPT_CIPHERS rijndael-arm.lo"
+-
+-         # Build with the ARMv8/AArch32 CE implementation
+-         GCRYPT_CIPHERS="$GCRYPT_CIPHERS rijndael-armv8-ce.lo"
+-         GCRYPT_CIPHERS="$GCRYPT_CIPHERS rijndael-armv8-aarch32-ce.lo"
+       ;;
+       aarch64-*-*)
+          # Build with the assembly implementation
+@@ -2355,10 +2351,6 @@
+          GCRYPT_DIGESTS="$GCRYPT_DIGESTS sha256-avx-amd64.lo"
+          GCRYPT_DIGESTS="$GCRYPT_DIGESTS sha256-avx2-bmi2-amd64.lo"
+       ;;
+-      arm*-*-*)
+-         # Build with the assembly implementation
+-         GCRYPT_DIGESTS="$GCRYPT_DIGESTS sha256-armv8-aarch32-ce.lo"
+-      ;;
+       aarch64-*-*)
+          # Build with the assembly implementation
+          GCRYPT_DIGESTS="$GCRYPT_DIGESTS sha256-armv8-aarch64-ce.lo"
+@@ -2448,7 +2440,6 @@
+   arm*-*-*)
+     # Build with the assembly implementation
+     GCRYPT_DIGESTS="$GCRYPT_DIGESTS sha1-armv7-neon.lo"
+-    GCRYPT_DIGESTS="$GCRYPT_DIGESTS sha1-armv8-aarch32-ce.lo"
+   ;;
+   aarch64-*-*)
+     # Build with the assembly implementation

--- a/tools/depends/target/libgcrypt/03-remove-cipher-gcm-armv8.patch
+++ b/tools/depends/target/libgcrypt/03-remove-cipher-gcm-armv8.patch
@@ -1,0 +1,10 @@
+--- cipher/Makefile.am.orig	2017-10-11 11:32:12.196210815 +0200
++++ cipher/Makefile.am	2017-10-11 11:32:54.668210405 +0200
+@@ -43,7 +43,6 @@
+ cipher.c cipher-internal.h \
+ cipher-cbc.c cipher-cfb.c cipher-ofb.c cipher-ctr.c cipher-aeswrap.c \
+ cipher-ccm.c cipher-cmac.c cipher-gcm.c cipher-gcm-intel-pclmul.c \
+-  cipher-gcm-armv8-aarch32-ce.S cipher-gcm-armv8-aarch64-ce.S \
+ cipher-poly1305.c cipher-ocb.c cipher-xts.c \
+ cipher-selftest.c cipher-selftest.h \
+ pubkey.c pubkey-internal.h pubkey-util.c \

--- a/tools/depends/target/libgcrypt/Makefile
+++ b/tools/depends/target/libgcrypt/Makefile
@@ -1,5 +1,5 @@
 include ../../Makefile.include
-DEPS= ../../Makefile.include 01-gcrypt-android-select.patch Makefile
+DEPS= ../../Makefile.include 01-gcrypt-android-select.patch 02-fix-armv7-neon.patch 03-remove-cipher-gcm-armv8.patch Makefile
 
 # lib name, version
 LIBNAME=libgcrypt
@@ -8,11 +8,14 @@ SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.bz2
 
 ifeq ($(OS),osx)
-CONFIGURE_FLAGS+= --disable-asm --disable-avx-support --disable-avx2-support
+  CONFIGURE_FLAGS+= --disable-asm --disable-avx-support --disable-avx2-support
 endif
-ifeq ($(CPU),arm64)
-CONFIGURE_FLAGS+= --disable-asm --disable-neon-support
+ifeq ($(findstring arm64, $(CPU)), arm64)
+  CONFIGURE_FLAGS+= --disable-asm
+else
+  CONFIGURE_FLAGS+= --disable-asm --disable-arm-crypto-support
 endif
+
 
 # configuration settings
 CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; \
@@ -32,6 +35,10 @@ $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 	rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
 	cd $(PLATFORM); patch -p0 < ../01-gcrypt-android-select.patch
+	cd $(PLATFORM); patch -p0 < ../02-fix-armv7-neon.patch
+ifneq ($(findstring arm64, $(CPU)), arm64)
+	cd $(PLATFORM); patch -p0 < ../03-remove-cipher-gcm-armv8.patch
+endif
 	# do not build the tests or docs
 	sed -ie "s|doc tests||" "$(PLATFORM)/Makefile.am"
 	sed -ie "s|\$$(doc) tests||" "$(PLATFORM)/Makefile.am"


### PR DESCRIPTION
v.1.8. added support for armv8 crypt extensions.  Detections seems broken and enables ARMv8 extensions on arm-v7